### PR TITLE
Exposes Prometheus from Nextsecurity installations

### DIFF
--- a/imageroot/actions/create-module/20initialize
+++ b/imageroot/actions/create-module/20initialize
@@ -46,3 +46,5 @@ EOF
 cat << EOF > secret.env
 API_SECRET=$secret
 EOF
+
+mkdir -p clients

--- a/imageroot/actions/create-module/30systemd
+++ b/imageroot/actions/create-module/30systemd
@@ -24,7 +24,7 @@ exec 1>&2 # Send any output to stderr, to not alter the action response protocol
 set -e
 
 # Install the Systemd unit for this module instance
-for f in ${AGENT_INSTALL_DIR}/systemd/*.service
+for f in ${AGENT_INSTALL_DIR}/systemd/*{.service,.path}
 do
     sname=$(basename $f | sed "s/nextsec-controller/${MODULE_ID}/")
     sed "s/MODULE_ID/${MODULE_ID}/g" $f > /etc/systemd/system/$sname

--- a/imageroot/bin/metrics_exporter_handler
+++ b/imageroot/bin/metrics_exporter_handler
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+import sys
+
+import agent
+
+if len(sys.argv) != 1:
+    raise ValueError('Missing path to generate provider from.')
+
+data = {
+    'hosts': [],
+    'labels': { '__metrics_path__': '/api/v1/allmetrics?format=prometheus&help=no' }
+}
+
+with os.scandir(sys.argv[0]) as it:
+    redis_client = agent.redis_connect(privileged=True)
+    for entry in it:
+        if entry.is_file():
+            with open(entry, 'r', encoding='utf-8') as file:
+                host = file.readline()
+                module_id = os.environ["MODULE_ID"]
+                data['hosts'].append(f"{host}:19999")
+                redis_client.hset(
+                    f'module/{module_id}/{entry.name}/srv/http/prometheus-metrics',
+                    'config', json.dumps(data))
+                redis_client.publish(
+                    f'module/{module_id}/event/service-prometheus-metrics-updated', '{}')

--- a/imageroot/systemd/nextsec-controller-metrics-exporter.path
+++ b/imageroot/systemd/nextsec-controller-metrics-exporter.path
@@ -1,0 +1,7 @@
+[Unit]
+Description=Watch for vpn connections from MODULE_ID-vpn.service
+BindsTo=MODULE_ID.service
+After=MODULE_ID-vpn.service
+
+[Path]
+PathChanged=/var/lib/nethserver/MODULE_ID/state/clients

--- a/imageroot/systemd/nextsec-controller-metrics-exporter.service
+++ b/imageroot/systemd/nextsec-controller-metrics-exporter.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Add client as service provider for prometheus
+BindsTo=MODULE_ID.service
+After=MODULE_ID-vpn.service
+
+[Service]
+ExecStart=/usr/local/bin/runagent metrics_exporter_handler /var/lib/nethserver/MODULE_ID/state/clients
+Type=oneshot

--- a/imageroot/systemd/nextsec-controller-vpn.service
+++ b/imageroot/systemd/nextsec-controller-vpn.service
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/podman run \
     --pod-id-file %t/MODULE_ID.pod-id \
     --replace -d --name MODULE_ID-vpn \
     -v MODULE_ID-vpn-data:/etc/openvpn/:z \
+    --volume=/var/lib/nethserver/MODULE_ID/state/clients:/etc/openvpn/clients \
     --env-file=/var/lib/nethserver/MODULE_ID/state/network.env \
     --env-file=/var/lib/nethserver/MODULE_ID/state/config.env \
     --network=host --cap-add=NET_ADMIN --device /dev/net/tun \

--- a/imageroot/systemd/nextsec-controller.service
+++ b/imageroot/systemd/nextsec-controller.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Podman MODULE_ID.service
-Requires=MODULE_ID-vpn.service MODULE_ID-api.service MODULE_ID-ui.service MODULE_ID-proxy.service MODULE_ID-promtail.service
-Before=MODULE_ID-vpn.service MODULE_ID-api.service MODULE_ID-ui.service MODULE_ID-proxy.service MODULE_ID-promtail.service
+Requires=MODULE_ID-vpn.service MODULE_ID-api.service MODULE_ID-ui.service MODULE_ID-proxy.service MODULE_ID-promtail.service MODULE_ID-notifier.path
+Before=MODULE_ID-vpn.service MODULE_ID-api.service MODULE_ID-ui.service MODULE_ID-proxy.service MODULE_ID-promtail.service MODULE_ID-notifier.path
 ConditionPathExists=/var/lib/nethserver/MODULE_ID/state/environment
 ConditionPathExists=/var/lib/nethserver/MODULE_ID/state/network.env
 


### PR DESCRIPTION
Added systemd path watcher and handler to expose nextsecurity installation as service providers for prometheus. Needs: NethServer/nextsecurity-controller#6
